### PR TITLE
Fix bug where numbers as command line arguments crashed

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -12,7 +12,9 @@ var cli = meow([
 	'',
 	'Example',
 	'  $ chalk red bold \'Unicorns & Rainbows\''
-]);
+], {
+	string: ['_']
+});
 
 var styles = cli.input;
 

--- a/test.js
+++ b/test.js
@@ -22,3 +22,17 @@ test('stdin', function (t) {
 		t.assert(stdout.trim() === chalk.red.bold('unicorn'));
 	});
 });
+
+test('number', function (t) {
+	t.plan(2);
+
+	childProcess.exec('./cli.js red bold 123 --no-stdin', function (err, stdout) {
+		t.assert(!err, err);
+		t.assert(stdout.trim() === chalk.red.bold('123'));
+	});
+
+	childProcess.exec('./cli.js red bold 0x2A --no-stdin', function (err, stdout) {
+		t.assert(!err, err);
+		t.assert(stdout.trim() === chalk.red.bold('0x2A'));
+	});
+});


### PR DESCRIPTION
When a number was used as a command line argument it was handed to the script as a javascript number by meow causing the replace call (cli.js:30) to fail. This is fixed by telling meow to give us raw strings instead of parsed values.

Many thanks for an awesome command line colouring utility!
