### PR TITLE
Add `--no-newline` flag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,8 +13,6 @@ jobs:
           - 14
           - 12
           - 10
-          - 8
-          - 6
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/cli.js
+++ b/cli.js
@@ -53,6 +53,7 @@ const cli = meow(`
 	  $ chalk -t '{red.bold Dungeons and Dragons {~bold.blue (with added fairies)}}'
 	  $ echo 'Unicorns from stdin' | chalk --stdin red bold
 `, {
+	allowUnknownFlags: false,
 	flags: {
 		template: {
 			type: 'string',

--- a/cli.js
+++ b/cli.js
@@ -42,9 +42,10 @@ const cli = meow(`
 	  $ echo <string> | chalk --stdin <style> …
 
 	Options
-	  --template, -t  Style template. The \`~\` character negates the style.
-	  --stdin         Read input from stdin rather than from arguments.
-	  --demo          Demo of all Chalk styles.
+	  --template, -t    Style template. The \`~\` character negates the style.
+	  --stdin           Read input from stdin rather than from arguments.
+	  --no-newline, -n  Don't emit a newline (\`\\n\`) after the input.
+	  --demo            Demo of all Chalk styles.
 
 	Examples
 	  $ chalk red bold 'Unicorns & Rainbows'
@@ -59,6 +60,10 @@ const cli = meow(`
 		},
 		stdin: {
 			type: 'boolean'
+		},
+		noNewline: {
+			type: 'boolean',
+			alias: 'n'
 		},
 		demo: {
 			type: 'boolean'
@@ -77,7 +82,10 @@ function init(data) {
 	}
 
 	const fn = dotProp.get(chalk, styles.join('.'));
-	console.log(fn(data.replace(/\n$/, '')));
+	process.stdout.write(fn(data.replace(/\n$/, '')));
+	if (!cli.flags.noNewline) {
+		process.stdout.write('\n');
+	}
 }
 
 if (process.stdin.isTTY || !cli.flags.stdin) {

--- a/cli.js
+++ b/cli.js
@@ -84,7 +84,21 @@ function init(data) {
 
 	const fn = dotProp.get(chalk, styles.join('.'));
 	process.stdout.write(fn(data.replace(/\n$/, '')));
-	if (!cli.flags.noNewline) {
+
+	// The following is unfortunately a bit complex, because we're trying to
+	// support both `-n` and `--no-newline` flags and this is a little tricky
+	// with the current state of [meow](https://www.npmjs.com/package/meow) and
+	// [yargs-parser](https://github.com/yargs/yargs-parser), which meow uses.
+	//
+	// There are two conditions in the following `if` statement:
+	//
+	//   - `cli.flags.noNewline` is set when `-n` is passed.
+	//   - `cli.flags.newline` is set to `false` when `--no-newline` is passed.
+	//
+	//  We're hoping to simplify this in the future. See:
+	//  https://github.com/chalk/chalk-cli/issues/30
+	//
+	if (!cli.flags.noNewline && cli.flags.newline !== false) {
 		process.stdout.write('\n');
 	}
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"node": ">=6"
 	},
 	"scripts": {
-		"test": "xo && ava"
+		"test": "xo && FORCE_COLOR=1 ava"
 	},
 	"files": [
 		"cli.js"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 		"chalk": "^2.0.0",
 		"dot-prop": "^3.0.0",
 		"get-stdin": "^6.0.0",
-		"meow": "^5.0.0"
+		"meow": "^9.0.0"
 	},
 	"devDependencies": {
 		"ava": "^0.25.0",

--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ $ chalk --help
   Options
     --template, -t    Style template. The `~` character negates the style.
     --stdin           Read input from stdin rather than from arguments.
-    --no-newline, -n  Don't emit a newline (\`\\n\`) after the input.
+    --no-newline, -n  Don't emit a newline (`\n`) after the input.
     --demo            Demo of all Chalk styles.
 
   Examples

--- a/readme.md
+++ b/readme.md
@@ -22,9 +22,10 @@ $ chalk --help
     $ echo <string> | chalk <style> ...
 
   Options
-    --template, -t  Style template. The `~` character negates the style.
-    --stdin         Read input from stdin rather than from arguments.
-    --demo          Demo of all Chalk styles.
+    --template, -t    Style template. The `~` character negates the style.
+    --stdin           Read input from stdin rather than from arguments.
+    --no-newline, -n  Don't emit a newline (\`\\n\`) after the input.
+    --demo            Demo of all Chalk styles.
 
   Examples
     $ chalk red bold 'Unicorns & Rainbows'

--- a/test.js
+++ b/test.js
@@ -43,3 +43,6 @@ test('without -n, output has trailing newline', macro,
 test('with -n, output has NO trailing newline', macro,
 	{args: ['-n', 'red', 'bold', 'unicorn'], opts: {stripEof: false}},
 	chalk.red.bold('unicorn') /* No trailing newline */);
+test('with --no-newline, output has NO trailing newline', macro,
+	{args: ['--no-newline', 'red', 'bold', 'unicorn'], opts: {stripEof: false}},
+	chalk.red.bold('unicorn') /* No trailing newline */);

--- a/test.js
+++ b/test.js
@@ -36,3 +36,10 @@ test('template escaping #1', templateMacro, '{red hey\\} still red} not red',
 	chalk.red('hey} still red') + ' not red');
 test('template escaping #2', templateMacro, '{red hey\\\\} not red',
 	chalk.red('hey\\') + ' not red');
+
+test('without -n, output has trailing newline', macro,
+	{args: ['red', 'bold', 'unicorn'], opts: {stripEof: false}},
+	chalk.red.bold('unicorn') + '\n');
+test('with -n, output has NO trailing newline', macro,
+	{args: ['-n', 'red', 'bold', 'unicorn'], opts: {stripEof: false}},
+	chalk.red.bold('unicorn') /* No trailing newline */);


### PR DESCRIPTION
Closes #13.

Opening a PR because I'd rather have a single `-n` option instead of also allowing `--bare`, but not sure if Meow can do that.