### PR TITLE
Don't use stdin unless `--stdin` flag is specified

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -39,18 +39,23 @@ const printAllStyles = () => {
 const cli = meow(`
 	Usage
 	  $ chalk <style> … <string>
-	  $ echo <string> | chalk <style> …
+	  $ echo <string> | chalk --stdin <style> …
 
 	Options
 	  --template, -t  Style template. The \`~\` character negates the style.
 	  --demo          Demo of all Chalk styles.
+	  --stdin         Read input from stdin rather than from arguments.
 
 	Examples
 	  $ chalk red bold 'Unicorns & Rainbows'
 	  $ chalk -t '{red.bold Unicorns & Rainbows}'
 	  $ chalk -t '{red.bold Dungeons and Dragons {~bold.blue (with added fairies)}}'
+	  $ echo 'Unicorns from stdin' | chalk --stdin red bold
 `, {
 	flags: {
+		stdin: {
+			type: 'boolean'
+		},
 		template: {
 			type: 'string',
 			alias: 't'
@@ -75,7 +80,7 @@ function init(data) {
 	console.log(fn(data.replace(/\n$/, '')));
 }
 
-if (process.stdin.isTTY || cli.flags.stdin === false) {
+if (process.stdin.isTTY || cli.flags.stdin !== true) {
 	if (cli.flags.demo) {
 		printAllStyles();
 	} else if (cli.flags.template) {

--- a/cli.js
+++ b/cli.js
@@ -43,8 +43,8 @@ const cli = meow(`
 
 	Options
 	  --template, -t  Style template. The \`~\` character negates the style.
-	  --demo          Demo of all Chalk styles.
 	  --stdin         Read input from stdin rather than from arguments.
+	  --demo          Demo of all Chalk styles.
 
 	Examples
 	  $ chalk red bold 'Unicorns & Rainbows'
@@ -53,12 +53,12 @@ const cli = meow(`
 	  $ echo 'Unicorns from stdin' | chalk --stdin red bold
 `, {
 	flags: {
-		stdin: {
-			type: 'boolean'
-		},
 		template: {
 			type: 'string',
 			alias: 't'
+		},
+		stdin: {
+			type: 'boolean'
 		},
 		demo: {
 			type: 'boolean'
@@ -80,7 +80,7 @@ function init(data) {
 	console.log(fn(data.replace(/\n$/, '')));
 }
 
-if (process.stdin.isTTY || cli.flags.stdin !== true) {
+if (process.stdin.isTTY || !cli.flags.stdin) {
 	if (cli.flags.demo) {
 		printAllStyles();
 	} else if (cli.flags.template) {

--- a/readme.md
+++ b/readme.md
@@ -23,12 +23,14 @@ $ chalk --help
 
   Options
     --template, -t  Style template. The `~` character negates the style.
+    --stdin         Read input from stdin rather than from arguments.
     --demo          Demo of all Chalk styles.
 
   Examples
     $ chalk red bold 'Unicorns & Rainbows'
     $ chalk -t '{red.bold Unicorns & Rainbows}'
     $ chalk -t '{red.bold Dungeons and Dragons {~bold.blue (with added fairies)}}'
+    $ echo 'Unicorns from stdin' | chalk --stdin red bold
 ```
 
 See [supported styles](https://github.com/chalk/chalk#styles).

--- a/test.js
+++ b/test.js
@@ -16,7 +16,9 @@ const templateMacro = (t, input, expected) => {
 
 test('main', macro, {args: ['red', 'bold', 'unicorn', '--no-stdin']},
 	chalk.red.bold('unicorn'));
-test('stdin', macro, {args: ['red', 'bold'], opts: {input: 'unicorn'}},
+test('default to args; not stdin (#11)', macro, {args: ['red', 'bold', 'unicorn'], opts: {input: ''}},
+	chalk.red.bold('unicorn'));
+test('stdin', macro, {args: ['red', 'bold', '--stdin'], opts: {input: 'unicorn'}},
 	chalk.red.bold('unicorn'));
 test('number', macro, {args: ['red', 'bold', '123', '--no-stdin']},
 	chalk.red.bold('123'));


### PR DESCRIPTION
Before:
-------

```
$ echo '' | FORCE_COLOR=1 node cli.js green 'this is a test'
Invalid style: this is a test
```

After:
-------

```
$ echo '' | FORCE_COLOR=1 node cli.js green 'this is a test'
this is a test

$ echo '' | FORCE_COLOR=1 node cli.js green 'this is a test' | cat
this is a test

$ echo 'text from stdin' | node cli.js --stdin green
text from stdin
```

Fixes #11