### PR TITLE
.editorconfig: Use spaces for .md files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,6 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.yml]
+[*.{md,yml}]
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
While editing `readme.md` for GH-17, I noticed that VS Code was
formatting lines with tabs for indentation and that it looked bad in the
diffs, because it wasn't matching the existing lines.

Ths updates `.editconfig` so that it uses spaces for indentation in
Markdown files, which seems to match what has been used.

```
$ git diff readme.md
diff --git a/readme.md b/readme.md
index 5a21992..e0f2c4a 100644
--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,8 @@ $ chalk --help
   Options
     --template, -t  Style template. The `~` character negates the style.
     --demo          Demo of all Chalk styles.
+               --fake-flag1    Fake flag added BEFORE updating .editorconfig to use spaces for Markdown files
+    --fake-flag2    Fake flag added AFTER updating .editorconfig to use spaces for Markdown files

   Examples
     $ chalk red bold 'Unicorns & Rainbows'
```