### PR TITLE
Better error for unknown flags

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -52,6 +52,7 @@ const cli = meow(`
 	  $ chalk -t '{red.bold Dungeons and Dragons {~bold.blue (with added fairies)}}'
 	  $ echo 'Unicorns from stdin' | chalk --stdin red bold
 `, {
+	allowUnknownFlags: false,
 	flags: {
 		template: {
 			type: 'string',

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 		"chalk": "^2.0.0",
 		"dot-prop": "^3.0.0",
 		"get-stdin": "^6.0.0",
-		"meow": "^5.0.0"
+		"meow": "^9.0.0"
 	},
 	"devDependencies": {
 		"ava": "^0.25.0",


### PR DESCRIPTION
Take advantage of `allowUnknownFlags` property in newer versions of [meow][] to show a better error message when a flag is unknown.

Before:
-------

```
$ node cli.js --foobar green "Hello there"
Input required
```

After:
------

```
$ node cli.js --foobar green "Hello there"
Unknown flag
--foobar
```

I'm also wondering if maybe some of the features and bug fixes in newer versions of meow could be useful for #16.

[meow]: https://www.npmjs.com/package/meow