### PR TITLE
Remove extra escaping of `\n` in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ $ chalk --help
   Options
     --template, -t    Style template. The `~` character negates the style.
     --stdin           Read input from stdin rather than from arguments.
-    --no-newline, -n  Don't emit a newline (\`\\n\`) after the input.
+    --no-newline, -n  Don't emit a newline (`\n`) after the input.
     --demo            Demo of all Chalk styles.
 
   Examples


### PR DESCRIPTION
There was extra escaping around `\n`, probably from copying directly
from `cli.js`. I copied from the output of `node cli.js --help`, which
gives the simpler, unescaped version.

Before:
-------

![Screen Shot 2021-09-13 at 12 19 05 PM](https://user-images.githubusercontent.com/305268/133144251-5c666ab5-48a4-4bcc-918d-368c2da4bc1e.png)

After:
------

![Screen Shot 2021-09-13 at 12 24 05 PM](https://user-images.githubusercontent.com/305268/133144205-3773c601-2d0c-4e6b-89dd-bbc80cf1c5e7.png)

See: https://github.com/chalk/chalk-cli/pull/16