### PR TITLE
package.json: Make author.url a URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"author": {
 		"name": "Sindre Sorhus",
 		"email": "sindresorhus@gmail.com",
-		"url": "sindresorhus.com"
+		"url": "https://sindresorhus.com"
 	},
 	"bin": {
 		"chalk": "cli.js"


### PR DESCRIPTION
Some tooling would prefer this to be a URI with a scheme and it's
rendering with a squiggly in VS code and I see no reason why not to have
a URL with a scheme.

![Screen Shot 2021-09-13 at 3 33 20 PM](https://user-images.githubusercontent.com/305268/133165259-105d0bea-7d91-46ff-9273-f4572bc2ee59.png)