### PR TITLE
Fix failing tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,8 +13,6 @@ jobs:
           - 14
           - 12
           - 10
-          - 8
-          - 6
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"node": ">=6"
 	},
 	"scripts": {
-		"test": "xo && ava"
+		"test": "xo && FORCE_COLOR=1 ava"
 	},
 	"files": [
 		"cli.js"


### PR DESCRIPTION
The GitHub Actions CI has been failing for a while because the output is not rendering colored. This is because `test.js` was setting `FORCE_COLOR=1` but this happens after the `import` of `chalk` and thus also after the import within chalk of [`supports-color`](https://www.npmjs.com/package/supports-color)

JS likes imports to be at the top of files before any other logic, so it's not really possible to set `FORCE_COLOR` any earlier within `test.js`. But it *is* possible to set it in `package.json` while invoking `ava`...

![Screen Shot 2021-09-13 at 4 27 18 PM](https://user-images.githubusercontent.com/305268/133169904-865a472c-ac72-4b23-83ca-7591f31093fd.png)

Fixes: GH-27

This PR also removes node versions 8 and 6 from the list of versions to test, because `yargs-parser` only supports node >= 10 now. Note that we go forward with converting chalk-cli to ESM (see https://github.com/chalk/chalk-cli/pull/26), then we will require node >= 12.

![Screen Shot 2021-09-13 at 4 25 52 PM](https://user-images.githubusercontent.com/305268/133169803-18379a4a-56b1-40fa-aa21-43e6f5e32b4a.png)

🎉 