### PR TITLE
Fix help flag

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -55,6 +55,9 @@ const cli = meow(`
 `, {
 	allowUnknownFlags: false,
 	flags: {
+		help: {
+			type: 'boolean'
+		},
 		template: {
 			type: 'string',
 			alias: 't'

--- a/test.js
+++ b/test.js
@@ -14,6 +14,15 @@ const templateMacro = (t, input, expected) => {
 	return macro(t, {args: ['--template', input, '--no-stdin']}, expected);
 };
 
+test('help',
+	async (t, {args, opts}, expectedRegex) => {
+		const stdout = await execa.stdout('./cli.js', args, opts);
+		t.regex(stdout, expectedRegex);
+	},
+	{args: ['--help']},
+	/Terminal string styling done right/
+);
+
 test('main', macro, {args: ['red', 'bold', 'unicorn', '--no-stdin']},
 	chalk.red.bold('unicorn'));
 test('default to args; not stdin (#11)', macro, {args: ['red', 'bold', 'unicorn'], opts: {input: ''}},


### PR DESCRIPTION
This fixes the issue of `--help` not working (and adds a test to prevent future breakages), mentioned in #32.