### PR TITLE
Print all styles

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -13,8 +13,16 @@ const printAllStyles = () => {
 		return arr.slice(arr.indexOf(startValue), arr.indexOf(endValue) + 1);
 	};
 
+	function styled(style, text) {
+		if (/^bg[^B]/.test(style)) {
+			text = chalk.black(text);
+		}
+		return chalk[style](text);
+	}
+
 	function showStyles(styles) {
-		console.log(styles.map(style => chalk[style](style)).join(' '));
+		const output = styles.map(style => styled(style, style)).join(' ');
+		console.log(output);
 	}
 
 	const textStyles = sliceByValue(allStyles, 'bold', 'strikethrough');

--- a/cli.js
+++ b/cli.js
@@ -7,7 +7,7 @@ import getStdin from 'get-stdin';
 import meow from 'meow';
 
 const printAllStyles = () => {
-	const styles = [
+	const allStyles = [
 		'bold',
 		'dim',
 		'italic',
@@ -32,8 +32,22 @@ const printAllStyles = () => {
 		'bgCyan',
 		'bgWhite',
 	];
+	allStyles.sliceByValue = function (startValue, endValue) {
+		return this.slice(this.indexOf(startValue), this.indexOf(endValue) + 1);
+	};
 
-	console.log(styles.map(style => chalk[style](style)).join(' '));
+	function showStyles(styles) {
+		console.log(styles.map(style => chalk[style](style)).join(' '));
+	}
+
+	const textStyles = allStyles.sliceByValue('bold', 'strikethrough');
+	const colorStyles = allStyles.sliceByValue('black', 'gray');
+	const bgColorStyles = allStyles.sliceByValue('bgBlack', 'bgWhite');
+
+	console.log('Available styles:\n');
+	showStyles(textStyles);
+	showStyles(colorStyles);
+	showStyles(bgColorStyles);
 };
 
 const cli = meow(`

--- a/cli.js
+++ b/cli.js
@@ -93,7 +93,8 @@ const styles = cli.input;
 function init(data) {
 	for (const style of styles) {
 		if (!Object.keys(ansiStyles).includes(style)) {
-			console.error(`Invalid style: ${style}`);
+			console.error(chalk`{red Invalid style: {bold ${style}}}\n`);
+			printAllStyles();
 			process.exit(1);
 		}
 	}

--- a/cli.js
+++ b/cli.js
@@ -7,31 +7,8 @@ import getStdin from 'get-stdin';
 import meow from 'meow';
 
 const printAllStyles = () => {
-	const allStyles = [
-		'bold',
-		'dim',
-		'italic',
-		'underline',
-		'inverse',
-		'strikethrough',
-		'black',
-		'red',
-		'green',
-		'yellow',
-		'blue',
-		'magenta',
-		'cyan',
-		'white',
-		'gray',
-		'bgBlack',
-		'bgRed',
-		'bgGreen',
-		'bgYellow',
-		'bgBlue',
-		'bgMagenta',
-		'bgCyan',
-		'bgWhite',
-	];
+	const allStyles = Object.keys(ansiStyles);
+
 	function sliceByValue(arr, startValue, endValue) {
 		return arr.slice(arr.indexOf(startValue), arr.indexOf(endValue) + 1);
 	};
@@ -41,13 +18,17 @@ const printAllStyles = () => {
 	}
 
 	const textStyles = sliceByValue(allStyles, 'bold', 'strikethrough');
-	const colorStyles = sliceByValue(allStyles, 'black', 'gray');
+	const colorStyles = sliceByValue(allStyles, 'black', 'gray').concat(['grey']);
+	const brightColorStyles = sliceByValue(allStyles, 'redBright', 'whiteBright');
 	const bgColorStyles = sliceByValue(allStyles, 'bgBlack', 'bgWhite');
+	const bgBrightColorStyles = sliceByValue(allStyles, 'bgBlackBright', 'bgWhiteBright');
 
 	console.log('Available styles:\n');
 	showStyles(textStyles);
 	showStyles(colorStyles);
+	showStyles(brightColorStyles);
 	showStyles(bgColorStyles);
+	showStyles(bgBrightColorStyles);
 };
 
 const cli = meow(`

--- a/cli.js
+++ b/cli.js
@@ -7,29 +7,24 @@ import getStdin from 'get-stdin';
 import meow from 'meow';
 
 const printAllStyles = () => {
-	const allStyles = Object.keys(ansiStyles);
-
-	function sliceByValue(arr, startValue, endValue) {
-		return arr.slice(arr.indexOf(startValue), arr.indexOf(endValue) + 1);
-	};
+	const textStyles = ['bold', 'dim', 'italic', 'underline', 'strikethrough'];
+	const colorStyles = ['black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white', 'gray'];
+	const brightColorStyles = ['blackBright', 'redBright', 'greenBright', 'yellowBright', 'blueBright', 'magentaBright', 'cyanBright', 'whiteBright'];
+	const bgColorStyles = ['bgBlack', 'bgRed', 'bgGreen', 'bgYellow', 'bgBlue', 'bgMagenta', 'bgCyan', 'bgWhite', 'bgGray'];
+	const bgBrightColorStyles = ['bgBlackBright', 'bgRedBright', 'bgGreenBright', 'bgYellowBright', 'bgBlueBright', 'bgMagentaBright', 'bgCyanBright', 'bgWhiteBright'];
 
 	function styled(style, text) {
 		if (/^bg[^B]/.test(style)) {
 			text = chalk.black(text);
 		}
+
 		return chalk[style](text);
 	}
 
-	function showStyles(styles) {
-		const output = styles.map(style => styled(style, style)).join(' ');
+	function showStyles(stylesArray) {
+		const output = stylesArray.map(style => styled(style, style)).join(' ');
 		console.log(output);
 	}
-
-	const textStyles = sliceByValue(allStyles, 'bold', 'strikethrough');
-	const colorStyles = sliceByValue(allStyles, 'black', 'gray').concat(['grey']);
-	const brightColorStyles = sliceByValue(allStyles, 'redBright', 'whiteBright');
-	const bgColorStyles = sliceByValue(allStyles, 'bgBlack', 'bgWhite');
-	const bgBrightColorStyles = sliceByValue(allStyles, 'bgBlackBright', 'bgWhiteBright');
 
 	console.log('Available styles:\n');
 	showStyles(textStyles);

--- a/cli.js
+++ b/cli.js
@@ -32,17 +32,17 @@ const printAllStyles = () => {
 		'bgCyan',
 		'bgWhite',
 	];
-	allStyles.sliceByValue = function (startValue, endValue) {
-		return this.slice(this.indexOf(startValue), this.indexOf(endValue) + 1);
+	function sliceByValue(arr, startValue, endValue) {
+		return arr.slice(arr.indexOf(startValue), arr.indexOf(endValue) + 1);
 	};
 
 	function showStyles(styles) {
 		console.log(styles.map(style => chalk[style](style)).join(' '));
 	}
 
-	const textStyles = allStyles.sliceByValue('bold', 'strikethrough');
-	const colorStyles = allStyles.sliceByValue('black', 'gray');
-	const bgColorStyles = allStyles.sliceByValue('bgBlack', 'bgWhite');
+	const textStyles = sliceByValue(allStyles, 'bold', 'strikethrough');
+	const colorStyles = sliceByValue(allStyles, 'black', 'gray');
+	const bgColorStyles = sliceByValue(allStyles, 'bgBlack', 'bgWhite');
 
 	console.log('Available styles:\n');
 	showStyles(textStyles);


### PR DESCRIPTION
1. Print available styles in several groups, one per line (textStyles, colorStyles, brightColorStyles, bgColorStyles, and bgBrightColorStyles).

2. Show available styles when invalid style provided (with a bit of extra color too for the error message).

![Screen Shot 2021-09-22 at 4 02 18 AM](https://user-images.githubusercontent.com/305268/134332434-b7716e10-c4d2-4bbd-8104-1c03b6f209b5.png)

![Screen Shot 2021-09-22 at 4 01 55 AM](https://user-images.githubusercontent.com/305268/134332480-59a1fa75-1b70-46b0-b4a1-386309c3095d.png)
