### PR TITLE
Restore `allowUnknownFlags: false`

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -52,9 +52,12 @@ const cli = meow(`
 	  $ echo 'Unicorns from stdin' | chalk --stdin red bold
 `, {
 	importMeta: import.meta,
-	// TODO: Disabled until https://github.com/sindresorhus/meow/issues/197 is fixed.
-	// allowUnknownFlags: false,
+	allowUnknownFlags: false,
 	flags: {
+		// TODO: Can be removed when https://github.com/sindresorhus/meow/issues/197 is fixed.
+		help: {type: 'boolean'},
+		version: {type: 'boolean'},
+
 		template: {
 			type: 'string',
 			alias: 't',

--- a/test.js
+++ b/test.js
@@ -60,3 +60,16 @@ test('with --no-newline, output has NO trailing newline', macro,
 	chalk.red.bold('unicorn') /* No trailing newline */);
 
 test('demo', snapshotMacro, {args: ['--demo']});
+
+test('unknown flag',
+	async (t, {args, opts}, expectedRegex) => {
+		try {
+			await execa('./cli.js', args, opts);
+		} catch (error) {
+			t.is(error.exitCode, 2);
+			t.regex(error.toString(), expectedRegex);
+		}
+	},
+	{args: ['--this-is-not-a-supported-flag'], opts: {input: 'unicorn'}},
+	/Unknown flag/,
+);


### PR DESCRIPTION
Currently, `allowUnknownFlags: false` is commented out, which is not ideal, because the error message the user gets when using an unknown flag is pretty confusing:

```
$ chalk --foobar
Input required
```

The actual problem is in [meow](https://github.com/sindresorhus/meow) (see sindresorhus/meow#197), but it's been taking a while to come up with a proper fix for that (see sindresorhus/meow#198), so I suggest using this workaround in the meantime.

See: #32, #33, #39, https://github.com/sindresorhus/meow/pull/197, https://github.com/sindresorhus/meow/pull/198