### PR TITLE
Add `-e` (`--escapes`) flag

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import process from 'node:process';
 import ansiStyles from 'ansi-styles';
+import backslash from 'backslash';
 import chalk from 'chalk';
 import dotProp from 'dot-prop';
 import getStdin from 'get-stdin';
@@ -43,6 +44,7 @@ const cli = meow(`
 	  --template, -t    Style template. The \`~\` character negates the style.
 	  --stdin           Read input from stdin rather than from arguments.
 	  --no-newline, -n  Don't emit a newline (\`\\n\`) after the input.
+	  --escapes, -e     Process backslash escapes such as \\t (tab) and \\b (backspace).
 	  --demo            Demo of all Chalk styles.
 
 	Examples
@@ -72,6 +74,10 @@ const cli = meow(`
 		noNewline: {
 			type: 'boolean',
 			alias: 'n',
+		},
+		escapes: {
+			type: 'boolean',
+			alias: 'e',
 		},
 		demo: {
 			type: 'boolean',
@@ -109,7 +115,12 @@ function init(data) {
 	}
 
 	const fn = dotProp.get(chalk, styles.join('.'));
-	process.stdout.write(fn(data.replace(/\n$/, '')));
+	let transformedData = data.replace(/\n$/, '');
+	if (cli.flags.escapes) {
+		transformedData = backslash(transformedData);
+	}
+
+	process.stdout.write(fn(transformedData));
 
 	// The following is unfortunately a bit complex, because we're trying to
 	// support both `-n` and `--no-newline` flags and this is a little tricky

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
 	],
 	"dependencies": {
 		"ansi-styles": "^6.1.0",
+		"backslash": "^0.2.0",
 		"chalk": "^4.1.2",
 		"dot-prop": "^6.0.1",
 		"get-stdin": "^9.0.0",

--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,7 @@ $ chalk --help
     --template, -t    Style template. The `~` character negates the style.
     --stdin           Read input from stdin rather than from arguments.
     --no-newline, -n  Don't emit a newline (`\n`) after the input.
+    --escapes, -e     Process backslash escapes such as \t (tab) and \b (backspace).
     --demo            Demo of all Chalk styles.
 
   Examples

--- a/test.js
+++ b/test.js
@@ -61,6 +61,13 @@ test('with --no-newline, output has NO trailing newline', macro,
 
 test('demo', snapshotMacro, {arguments: ['--demo']});
 
+test('backslash escapes - \\t', macro,
+	{arguments: ['red', 'bold', '\\tunicorn', '-e']},
+	chalk.red.bold('\tunicorn'));
+test('backslash escapes - \\b', macro,
+	{arguments: ['red', 'bold', 'unicork\\bn', '-e']},
+	chalk.red.bold('unicork\bn'));
+
 test('unknown flag',
 	async (t, {arguments: arguments_, options}, expectedRegex) => {
 		try {


### PR DESCRIPTION
This allows using escapes such as `\t` and `\b`.

```
$ chalk -e green '\tThis is a test'
	This is a test

$ chalk -e green 'This is a tesq\bt'
This is a test
```