### PR TITLE
VS Code: No spaces for braces

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "javascript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": false
+}


### PR DESCRIPTION
VS Code by default wants to put spaces after opening curly braces and
before closing curly braces and this is not the style in use here, so
it's a bit tedious to have to undo this one aspect of VS Code's
auto-formatting.