### PR TITLE
Color flag support

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import process from 'node:process';
 import ansiStyles from 'ansi-styles';
-import chalk, {supportsColor} from 'chalk'; // eslint-disable-line unicorn/import-style
+import chalk from 'chalk';
 import chalkTemplate from 'chalk-template';
 import {getProperty} from 'dot-prop';
 import getStdin from 'get-stdin';
@@ -48,7 +48,6 @@ const cli = meow(`
 	  ${chalk.yellow('--no-newline, -n')}  Don't emit a newline (\`\\n\`) after the input.
 	  ${chalk.yellow('--demo')}            Demo of all Chalk styles.
 	  ${chalk.yellow('--color, -c')}       Behave as FORCE_COLOR set to given value (0, 1, 2, 3, 256, 16m).
-	  ${chalk.yellow('--force-color, -f')} Force color display.
 
 	${chalk.redBright.inverse(' Examples ')}
 
@@ -84,9 +83,8 @@ const cli = meow(`
 		},
 		color: {
 			type: 'string',
-			choices: ['0', '1', '2', '3', '256', '16m'],
 		},
-		forceColor: {
+		colors: {
 			type: 'boolean',
 		},
 		noNewline: {
@@ -177,12 +175,6 @@ async function processDataFromStdin() {
 	}
 
 	init(await getStdin());
-}
-
-if (cli.flags.forceColor) {
-	chalk.level = supportsColor.level;
-} else if (cli.flags.color !== undefined) {
-	chalk.level = cli.flags.color;
 }
 
 if (process.stdin.isTTY || !cli.flags.stdin) {

--- a/cli.js
+++ b/cli.js
@@ -46,6 +46,8 @@ const cli = meow(`
 	  ${chalk.yellow('--stdin')}           Read input from stdin rather than from arguments.
 	  ${chalk.yellow('--no-newline, -n')}  Don't emit a newline (\`\\n\`) after the input.
 	  ${chalk.yellow('--demo')}            Demo of all Chalk styles.
+	  ${chalk.yellow('--color, -c')}       Behave as FORCE_COLOR set to given value (0, 1, 2, 3, 256, 16m).
+	  ${chalk.yellow('--force-color, -f')} Force color display.
 
 	${chalk.redBright.inverse(' Examples ')}
 
@@ -77,6 +79,13 @@ const cli = meow(`
 			alias: 't',
 		},
 		stdin: {
+			type: 'boolean',
+		},
+		color: {
+			type: 'string',
+			choices: [0, 1, 2, 3, 256, '16m'],
+		},
+		forceColor: {
 			type: 'boolean',
 		},
 		noNewline: {
@@ -167,6 +176,12 @@ async function processDataFromStdin() {
 	}
 
 	init(await getStdin());
+}
+
+if (cli.flags.forceColor) {
+	chalk.level = 1;
+} else if (cli.flags.color !== undefined) {
+	chalk.level = cli.flags.color;
 }
 
 if (process.stdin.isTTY || !cli.flags.stdin) {

--- a/cli.js
+++ b/cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import process from 'node:process';
 import ansiStyles from 'ansi-styles';
-import chalk from 'chalk';
+import chalk, {supportsColor} from 'chalk'; // eslint-disable-line unicorn/import-style
 import chalkTemplate from 'chalk-template';
 import {getProperty} from 'dot-prop';
 import getStdin from 'get-stdin';
@@ -180,7 +180,7 @@ async function processDataFromStdin() {
 }
 
 if (cli.flags.forceColor) {
-	chalk.level = 1;
+	chalk.level = supportsColor.level;
 } else if (cli.flags.color !== undefined) {
 	chalk.level = cli.flags.color;
 }

--- a/cli.js
+++ b/cli.js
@@ -2,7 +2,8 @@
 import process from 'node:process';
 import ansiStyles from 'ansi-styles';
 import chalk from 'chalk';
-import dotProp from 'dot-prop';
+import chalkTemplate from 'chalk-template';
+import {getProperty} from 'dot-prop';
 import getStdin from 'get-stdin';
 import meow from 'meow';
 
@@ -58,7 +59,7 @@ const cli = meow(`
 	  ${chalk.red.bold('Unicorns & Rainbows')}
 
 	  $ chalk -t '{red.bold Dungeons and Dragons {~bold.blue (with added fairies)}}'
-	  ${chalk`{red.bold Dungeons and Dragons {~bold.blue (with added fairies)}}`}
+	  ${chalkTemplate`{red.bold Dungeons and Dragons {~bold.blue (with added fairies)}}`}
 
 	  $ echo 'Unicorns from stdin' | chalk --stdin red bold
 	  ${chalk.red.bold('Unicorns from stdin')}
@@ -76,21 +77,21 @@ const cli = meow(`
 
 		template: {
 			type: 'string',
-			alias: 't',
+			shortFlag: 't',
 		},
 		stdin: {
 			type: 'boolean',
 		},
 		color: {
 			type: 'string',
-			choices: [0, 1, 2, 3, 256, '16m'],
+			choices: ['0', '1', '2', '3', '256', '16m'],
 		},
 		forceColor: {
 			type: 'boolean',
 		},
 		noNewline: {
 			type: 'boolean',
-			alias: 'n',
+			shortFlag: 'n',
 		},
 		demo: {
 			type: 'boolean',
@@ -110,7 +111,7 @@ function handleTemplateFlag(template) {
 	try {
 		const tagArray = [template];
 		tagArray.raw = tagArray;
-		console.log(chalk(tagArray));
+		console.log(chalkTemplate(tagArray));
 	} catch (error) {
 		console.error('Something went wrong! Maybe review your syntax?\n');
 		console.error(error.stack);
@@ -121,13 +122,13 @@ function handleTemplateFlag(template) {
 function init(data) {
 	for (const style of styles) {
 		if (!Object.keys(ansiStyles).includes(style)) {
-			console.error(chalk`{red Invalid style: {bold ${style}}}\n`);
+			console.error(chalkTemplate`{red Invalid style: {bold ${style}}}\n`);
 			printAllStyles();
 			process.exit(1);
 		}
 	}
 
-	const fn = dotProp.get(chalk, styles.join('.'));
+	const fn = getProperty(chalk, styles.join('.'));
 	process.stdout.write(fn(data.replace(/\n$/, '')));
 
 	// The following is unfortunately a bit complex, because we're trying to

--- a/cli.js
+++ b/cli.js
@@ -47,7 +47,7 @@ const cli = meow(`
 	  ${chalk.yellow('--stdin')}           Read input from stdin rather than from arguments.
 	  ${chalk.yellow('--no-newline, -n')}  Don't emit a newline (\`\\n\`) after the input.
 	  ${chalk.yellow('--demo')}            Demo of all Chalk styles.
-	  ${chalk.yellow('--color, -c')}       Behave as FORCE_COLOR set to given value (0, 1, 2, 3, 256, 16m).
+	  ${chalk.yellow('--color, -c')}       Force color support.
 
 	${chalk.redBright.inverse(' Examples ')}
 
@@ -82,9 +82,6 @@ const cli = meow(`
 			type: 'boolean',
 		},
 		color: {
-			type: 'string',
-		},
-		colors: {
 			type: 'boolean',
 		},
 		noNewline: {

--- a/package.json
+++ b/package.json
@@ -49,15 +49,16 @@
 		"template"
 	],
 	"dependencies": {
-		"ansi-styles": "^6.1.0",
-		"chalk": "^4.1.2",
-		"dot-prop": "^6.0.1",
+		"ansi-styles": "^6.2.1",
+		"chalk": "^5.4.1",
+		"chalk-template": "^1.1.0",
+		"dot-prop": "^9.0.0",
 		"get-stdin": "^9.0.0",
-		"meow": "^10.1.1"
+		"meow": "^13.2.0"
 	},
 	"devDependencies": {
 		"ava": "^3.15.0",
-		"execa": "^5.1.1",
+		"execa": "^9.5.2",
 		"xo": "^0.44.0"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -24,8 +24,7 @@ $ chalk --help
     --stdin           Read input from stdin rather than from arguments.
     --no-newline, -n  Don't emit a newline (`\n`) after the input.
     --demo            Demo of all Chalk styles.
-    --color, -c       Behave as FORCE_COLOR set to given value (0, 1, 2, 3, 256, 16m).
-    --force-color, -f Force color display.
+    --color, -c       Force color support.
 
   Examples
     $ chalk red bold 'Unicorns & Rainbows'

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,8 @@ $ chalk --help
     --stdin           Read input from stdin rather than from arguments.
     --no-newline, -n  Don't emit a newline (`\n`) after the input.
     --demo            Demo of all Chalk styles.
+    --color, -c       Behave as FORCE_COLOR set to given value (0, 1, 2, 3, 256, 16m).
+    --force-color, -f Force color display.
 
   Examples
     $ chalk red bold 'Unicorns & Rainbows'

--- a/test.js
+++ b/test.js
@@ -61,6 +61,18 @@ test('with --no-newline, output has NO trailing newline', macro,
 
 test('demo', snapshotMacro, {arguments: ['--demo']});
 
+test('force-color', macro, {arguments: ['red', 'bold', 'unicorn', '--force-color']},
+	chalk.red.bold('unicorn'));
+
+test('color 3', macro, {arguments: ['red', 'bold', 'unicorn', '--color', '3']},
+	chalk.red.bold('unicorn'));
+
+test('color 0', macro, {arguments: ['red', 'bold', 'unicorn', '--color', '0']},
+	'unicorn');
+
+test('no color', macro, {arguments: ['--no-color', 'red', 'bold', 'unicorn']},
+	'unicorn');
+
 test('unknown flag',
 	async (t, {arguments: arguments_, options}, expectedRegex) => {
 		try {

--- a/test.js
+++ b/test.js
@@ -61,8 +61,14 @@ test('with --no-newline, output has NO trailing newline', macro,
 
 test('demo', snapshotMacro, {arguments: ['--demo']});
 
-test('color 3', macro, {arguments: ['red', 'bold', 'unicorn', '--color', '3']},
+test('color', macro, {arguments: ['yellow', 'bold', 'unicorn', '--color']},
+	chalk.yellow.bold('unicorn'));
+
+test('color=always', macro, {arguments: ['red', 'bold', 'unicorn', '--color=always']},
 	chalk.red.bold('unicorn'));
+
+test('color=true', macro, {arguments: ['blue', 'bold', 'unicorn', '--color=true']},
+	chalk.blue.bold('unicorn'));
 
 /* This case is not testable as FORCE_COLOR is set, and takes precedence over flag
 test('no color', macro, {arguments: ['--no-color', 'red', 'bold', 'unicorn']},

--- a/test.js
+++ b/test.js
@@ -61,17 +61,13 @@ test('with --no-newline, output has NO trailing newline', macro,
 
 test('demo', snapshotMacro, {arguments: ['--demo']});
 
-test('force-color', macro, {arguments: ['red', 'bold', 'unicorn', '--force-color']},
-	chalk.red.bold('unicorn'));
-
 test('color 3', macro, {arguments: ['red', 'bold', 'unicorn', '--color', '3']},
 	chalk.red.bold('unicorn'));
 
-test('color 0', macro, {arguments: ['red', 'bold', 'unicorn', '--color', '0']},
-	'unicorn');
-
+/* This case is not testable as FORCE_COLOR is set, and takes precedence over flag
 test('no color', macro, {arguments: ['--no-color', 'red', 'bold', 'unicorn']},
 	'unicorn');
+*/
 
 test('unknown flag',
 	async (t, {arguments: arguments_, options}, expectedRegex) => {

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 import test from 'ava';
 import chalk from 'chalk';
-import execa from 'execa';
+import {execa} from 'execa';
 
 chalk.level = 1;
 


### PR DESCRIPTION
Support `--color` and `--force-color flag` to force color display in terminal. 
(Original use case come from crafting a colored message in fzf preview)

Took the opportunity to bump the underneath main dependancies, notably chalk itself.

 